### PR TITLE
Change Vector to AbstracVector in template type

### DIFF
--- a/src/change_form.jl
+++ b/src/change_form.jl
@@ -1,5 +1,5 @@
-function change_form(::Type{LPForm{T, AT}}, lp::LPForm) where {T, AT}
-    return LPForm{T, AT}(
+function change_form(::Type{LPForm{T, AT, VT}}, lp::LPForm) where {T, AT, VT}
+    return LPForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
@@ -10,8 +10,8 @@ function change_form(::Type{LPForm{T, AT}}, lp::LPForm) where {T, AT}
     )
 end
 
-function change_form(::Type{LPForm{T, AT}}, lp::LPStandardForm{T}) where {T, AT}
-    return LPForm{T, AT}(
+function change_form(::Type{LPForm{T, AT, VT}}, lp::LPStandardForm{T}) where {T, AT, VT}
+    return LPForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
@@ -21,8 +21,8 @@ function change_form(::Type{LPForm{T, AT}}, lp::LPStandardForm{T}) where {T, AT}
         fill(typemax(T), length(lp.c)),
     )
 end
-function change_form(::Type{LPForm{T, AT}}, lp::LPGeometricForm{T}) where {T, AT}
-    return LPForm{T, AT}(
+function change_form(::Type{LPForm{T, AT, VT}}, lp::LPGeometricForm{T}) where {T, AT, VT}
+    return LPForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
@@ -32,7 +32,7 @@ function change_form(::Type{LPForm{T, AT}}, lp::LPGeometricForm{T}) where {T, AT
         fill(typemax(T), length(lp.c)),
     )
 end
-function change_form(::Type{LPForm{T, AT}}, lp::LPSolverForm{T}) where {T, AT}
+function change_form(::Type{LPForm{T, AT, VT}}, lp::LPSolverForm{T}) where {T, AT, VT}
     c_lb = fill(typemin(T), length(lp.b))
     c_ub = fill(typemax(T), length(lp.b))
     for i in eachindex(lp.b)
@@ -47,7 +47,7 @@ function change_form(::Type{LPForm{T, AT}}, lp::LPSolverForm{T}) where {T, AT}
             error("invalid sign $(lp.senses[i])")
         end
     end
-    return LPForm{T, AT}(
+    return LPForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
@@ -58,15 +58,15 @@ function change_form(::Type{LPForm{T, AT}}, lp::LPSolverForm{T}) where {T, AT}
     )
 end
 
-function change_form(::Type{LPGeometricForm{T, AT}}, lp::LPGeometricForm) where {T, AT}
-    return LPGeometricForm{T, AT}(
+function change_form(::Type{LPGeometricForm{T, AT, VT}}, lp::LPGeometricForm) where {T, AT, VT}
+    return LPGeometricForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
         lp.b
     )
 end
-function change_form(::Type{LPGeometricForm{T, AT}}, lp::LPForm{T}) where {T, AT}
+function change_form(::Type{LPGeometricForm{T, AT, VT}}, lp::LPForm{T}) where {T, AT, VT}
     has_c_upper = Int[]
     has_c_lower = Int[]
     sizehint!(has_c_upper, length(lp.c_ub))
@@ -104,19 +104,19 @@ function change_form(::Type{LPGeometricForm{T, AT}}, lp::LPForm{T}) where {T, AT
         lp.v_ub[has_v_upper],
         -lp.v_lb[has_v_lower],
     )
-    return LPGeometricForm{T, AT}(
+    return LPGeometricForm{T, AT, VT}(
         lp.direction,
         lp.c,
         new_A,
         new_b
     )
 end
-function change_form(::Type{LPGeometricForm{T, AT}}, lp::F) where {T, AT, F <: AbstractLPForm{T}}
-    temp_lp = change_form(LPForm{T, AT}, lp)
-    return change_form(LPGeometricForm{T, AT}, temp_lp)
+function change_form(::Type{LPGeometricForm{T, AT, VT}}, lp::F) where {T, AT, VT, F <: AbstractLPForm{T}}
+    temp_lp = change_form(LPForm{T, AT, VT}, lp)
+    return change_form(LPGeometricForm{T, AT, VT}, temp_lp)
 end
 
-function change_form(::Type{LPStandardForm{T, AT}}, lp::LPStandardForm) where {T, AT}
+function change_form(::Type{LPStandardForm{T, AT, VT}}, lp::LPStandardForm) where {T, AT, VT}
     return LPStandardForm(
         lp.direction,
         lp.c,
@@ -124,7 +124,7 @@ function change_form(::Type{LPStandardForm{T, AT}}, lp::LPStandardForm) where {T
         lp.b
     )
 end
-function change_form(::Type{LPStandardForm{T, AT}}, lp::LPGeometricForm{T}) where {T, AT}
+function change_form(::Type{LPStandardForm{T, AT, VT}}, lp::LPGeometricForm{T}) where {T, AT, VT}
     new_A = hcat(
         lp.A,
         -lp.A,
@@ -135,21 +135,21 @@ function change_form(::Type{LPStandardForm{T, AT}}, lp::LPGeometricForm{T}) wher
         -lp.c,
         fill(0.0, length(lp.b))
     )
-    return LPStandardForm{T, AT}(
+    return LPStandardForm{T, AT, VT}(
         lp.direction,
         new_c,
         new_A,
         copy(lp.b)
     )
 end
-function change_form(::Type{LPStandardForm{T, AT}}, lp::F) where {T, AT, F <: AbstractLPForm{T}}
-    temp_lp = change_form(LPForm{T, AT}, lp)
-    new_lp = change_form(LPGeometricForm{T, AT}, temp_lp)
-    change_form(LPStandardForm{T, AT}, new_lp)
+function change_form(::Type{LPStandardForm{T, AT, VT}}, lp::F) where {T, AT, VT, F <: AbstractLPForm{T}}
+    temp_lp = change_form(LPForm{T, AT, VT}, lp)
+    new_lp = change_form(LPGeometricForm{T, AT, VT}, temp_lp)
+    change_form(LPStandardForm{T, AT, VT}, new_lp)
 end
 
-function change_form(::Type{LPSolverForm{T, AT}}, lp::LPSolverForm) where {T, AT}
-    return LPSolverForm{T, AT}(
+function change_form(::Type{LPSolverForm{T, AT, VT}}, lp::LPSolverForm) where {T, AT, VT}
+    return LPSolverForm{T, AT, VT}(
         lp.direction,
         lp.c,
         lp.A,
@@ -159,7 +159,7 @@ function change_form(::Type{LPSolverForm{T, AT}}, lp::LPSolverForm) where {T, AT
         lp.v_ub
     )
 end
-function change_form(::Type{LPSolverForm{T, AT}}, lp::LPForm{T}) where {T, AT}
+function change_form(::Type{LPSolverForm{T, AT, VT}}, lp::LPForm{T}) where {T, AT, VT}
     new_A = copy(lp.A)
     senses = fill(LESS_THAN, length(lp.c_lb))
     new_b = fill(NaN, length(lp.c_lb))
@@ -181,7 +181,7 @@ function change_form(::Type{LPSolverForm{T, AT}}, lp::LPForm{T}) where {T, AT}
             new_b[i] = lp.c_ub[i]
         end
     end
-    return LPSolverForm{T, AT}(
+    return LPSolverForm{T, AT, VT}(
         lp.direction,
         lp.c,
         new_A,
@@ -191,7 +191,7 @@ function change_form(::Type{LPSolverForm{T, AT}}, lp::LPForm{T}) where {T, AT}
         lp.v_ub,
     )
 end
-function change_form(::Type{LPSolverForm{T, AT}}, lp::F) where {T, AT, F <: AbstractLPForm{T}}
-    temp_lp = change_form(LPForm{T, AT}, lp)
-    change_form(LPSolverForm{T, AT}, temp_lp)
+function change_form(::Type{LPSolverForm{T, AT, VT}}, lp::F) where {T, AT, VT, F <: AbstractLPForm{T}}
+    temp_lp = change_form(LPForm{T, AT, VT}, lp)
+    change_form(LPSolverForm{T, AT, VT}, temp_lp)
 end

--- a/src/matrix_input.jl
+++ b/src/matrix_input.jl
@@ -47,11 +47,11 @@ function MOI.get(model::AbstractLPForm{T}, ::MOI.ConstraintFunction,
 end
 
 
-struct LPStandardForm{T, AT<:AbstractMatrix{T}} <: AbstractLPForm{T}
+struct LPStandardForm{T, AT<:AbstractMatrix{T}, VT <: AbstractVector{T}} <: AbstractLPForm{T}
     direction::MOI.OptimizationSense
-    c::Vector{T}
+    c::VT
     A::AT
-    b::Vector{T}
+    b::VT
 end
 
 function MOI.get(model::LPStandardForm{T}, ::MOI.ListOfConstraints) where T
@@ -91,11 +91,11 @@ function MOI.get(model::LPStandardForm, ::MOI.ConstraintSet,
     return MOI.Nonnegatives(MOI.get(model, MOI.NumberOfVariables()))
 end
 
-struct LPGeometricForm{T, AT<:AbstractMatrix{T}} <: AbstractLPForm{T}
+struct LPGeometricForm{T, AT<:AbstractMatrix{T}, VT <: AbstractVector{T}} <: AbstractLPForm{T}
     direction::MOI.OptimizationSense
-    c::Vector{T}
+    c::VT
     A::AT
-    b::Vector{T}
+    b::VT
 end
 
 function MOI.get(model::LPGeometricForm{T}, ::MOI.ListOfConstraints) where T
@@ -181,14 +181,14 @@ function MOI.get(model::LPMixedForm, ::MOI.ConstraintSet, ci::VBOUND)
     return _bound_set(model.v_lb[ci.value], model.v_ub[ci.value])
 end
 
-struct LPForm{T, AT<:AbstractMatrix{T}} <: LPMixedForm{T}#, V<:AbstractVector{T}, M<:AbstractMatrix{T}}
+struct LPForm{T, AT<:AbstractMatrix{T}, VT <: AbstractVector{T}} <: LPMixedForm{T} #, V<:AbstractVector{T} #, M<:AbstractMatrix{T}}
     direction::MOI.OptimizationSense
-    c::Vector{T}
+    c::VT
     A::AT
-    c_lb::Vector{T}
-    c_ub::Vector{T}
-    v_lb::Vector{T}
-    v_ub::Vector{T}
+    c_lb::VT
+    c_ub::VT
+    v_lb::VT
+    v_ub::VT
 end
 
 function _constraint_bound_sense(model::LPForm, i)
@@ -198,14 +198,14 @@ function MOI.get(model::LPForm, ::MOI.ConstraintSet, ci::AFF)
     return _bound_set(model.c_lb[ci.value], model.c_ub[ci.value])
 end
 
-struct LPSolverForm{T, AT<:AbstractMatrix{T}} <: LPMixedForm{T}
+struct LPSolverForm{T, AT<:AbstractMatrix{T}, VT<:AbstractVector{T}} <: LPMixedForm{T}
     direction::MOI.OptimizationSense
-    c::Vector{T}
+    c::VT
     A::AT
-    b::Vector{T}
+    b::VT
     senses::Vector{ConstraintSense}
-    v_lb::Vector{T}
-    v_ub::Vector{T}
+    v_lb::VT
+    v_ub::VT
 end
 
 function _constraint_bound_sense(model::LPSolverForm, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,8 @@ const dense_A = [1.0 2.0
 @testset "Matrix $(typeof(A))" for A in [
     dense_A, sparse(dense_A)
 ]
-    b = [5, 6]
-    c = [7, 8]
+    b = [5.0, 6.0]
+    c = [7.0, 8.0]
     @testset "Standard form LP" begin
         s = """
         variables: x1, x2
@@ -44,21 +44,21 @@ const dense_A = [1.0 2.0
         end
 
         @testset "change $(typeof(lp))" for lp in [
-            MatOI.LPStandardForm{Float64, typeof(A)}(
+            MatOI.LPStandardForm{Float64, typeof(A), typeof(c)}(
                 sense, c, A, b
             ),
-            MatOI.LPForm{Float64, typeof(A)}(
+            MatOI.LPForm{Float64, typeof(A), typeof(c)}(
                 sense, c, A, b, b, v_lb, v_ub
             ),
-            MatOI.LPSolverForm{Float64, typeof(A)}(
+            MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}(
                 sense, c, A, b, [MatOI.EQUAL_TO, MatOI.EQUAL_TO], v_lb, v_ub
             )
         ]
             test_expected(lp)
             @testset "to $F" for F in [
                 #MatOI.LPStandardForm{Float64, typeof(A)}, # FIXME doesn't work as the form gets bloated in the conversion
-                MatOI.LPForm{Float64, typeof(A)},
-                MatOI.LPSolverForm{Float64, typeof(A)}
+                MatOI.LPForm{Float64, typeof(A), typeof(c)},
+                MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
             ]
                 test_expected(MatOI.change_form(F, lp))
             end
@@ -90,21 +90,21 @@ const dense_A = [1.0 2.0
         end
 
         @testset "change $(typeof(lp))" for lp in [
-            MatOI.LPGeometricForm{Float64, typeof(A')}(
+            MatOI.LPGeometricForm{Float64, typeof(A'), typeof(c)}(
                 sense, b, A', c
             ),
-            MatOI.LPForm{Float64, typeof(A')}(
+            MatOI.LPForm{Float64, typeof(A'), typeof(c)}(
                 sense, b, A', [-Inf, -Inf], c, v_lb, v_ub
             ),
-            MatOI.LPSolverForm{Float64, typeof(A')}(
+            MatOI.LPSolverForm{Float64, typeof(A'), typeof(c)}(
                 sense, b, A', c, [MatOI.LESS_THAN, MatOI.LESS_THAN], v_lb, v_ub
             )
         ]
             test_expected(lp)
             @testset "to $F" for F in [
-                MatOI.LPGeometricForm{Float64, typeof(A)},
-                MatOI.LPForm{Float64, typeof(A)},
-                MatOI.LPSolverForm{Float64, typeof(A)}
+                MatOI.LPGeometricForm{Float64, typeof(A), typeof(c)},
+                MatOI.LPForm{Float64, typeof(A), typeof(c)},
+                MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
             ]
                 test_expected(MatOI.change_form(F, lp))
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,101 +12,105 @@ const dense_A = [1.0 2.0
 @testset "Matrix $(typeof(A))" for A in [
     dense_A, sparse(dense_A)
 ]
-    b = [5.0, 6.0]
-    c = [7.0, 8.0]
-    @testset "Standard form LP" begin
-        s = """
-        variables: x1, x2
-        cx1: x1 >= 0.0
-        cx2: x2 >= 0.0
-        c1:  x1 + 2x2 == 5.0
-        c2: 3x1 + 4x2 == 6.0
-        minobjective: 7x1 + 8x2
-        """
-        expected = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(expected, s)
+    dense_b = [5.0, 6.0]
+    dense_c = [7.0, 8.0]
+    @testset "Vector $(typeof(b))" for (b, c) in zip(
+        [dense_b, sparsevec(dense_b)], [dense_c, sparsevec(dense_c)]
+    )
+        @testset "Standard form LP" begin
+            s = """
+            variables: x1, x2
+            cx1: x1 >= 0.0
+            cx2: x2 >= 0.0
+            c1:  x1 + 2x2 == 5.0
+            c2: 3x1 + 4x2 == 6.0
+            minobjective: 7x1 + 8x2
+            """
+            expected = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(expected, s)
 
-        var_names = ["x1", "x2"]
-        con_names = ["c1", "c2"]
-        vcon_names = ["cx1", "cx2"]
-        model = MOIU.Model{Float64}()
+            var_names = ["x1", "x2"]
+            con_names = ["c1", "c2"]
+            vcon_names = ["cx1", "cx2"]
+            model = MOIU.Model{Float64}()
 
-        sense = MOI.MIN_SENSE
-        v_lb = [0.0, 0.0]
-        v_ub = [Inf, Inf]
+            sense = MOI.MIN_SENSE
+            v_lb = [0.0, 0.0]
+            v_ub = [Inf, Inf]
 
-        function test_expected(form)
-            MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form, copy_names = false)
-            MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
-            MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
-            MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
-            MOIU.test_models_equal(model, expected, var_names, [con_names; vcon_names])
-        end
+            function test_expected(form)
+                MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form, copy_names = false)
+                MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
+                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
+                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
+                MOIU.test_models_equal(model, expected, var_names, [con_names; vcon_names])
+            end
 
-        @testset "change $(typeof(lp))" for lp in [
-            MatOI.LPStandardForm{Float64, typeof(A), typeof(c)}(
-                sense, c, A, b
-            ),
-            MatOI.LPForm{Float64, typeof(A), typeof(c)}(
-                sense, c, A, b, b, v_lb, v_ub
-            ),
-            MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}(
-                sense, c, A, b, [MatOI.EQUAL_TO, MatOI.EQUAL_TO], v_lb, v_ub
-            )
-        ]
-            test_expected(lp)
-            @testset "to $F" for F in [
-                #MatOI.LPStandardForm{Float64, typeof(A)}, # FIXME doesn't work as the form gets bloated in the conversion
-                MatOI.LPForm{Float64, typeof(A), typeof(c)},
-                MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
+            @testset "change $(typeof(lp))" for lp in [
+                MatOI.LPStandardForm{Float64, typeof(A), typeof(c)}(
+                    sense, c, A, b
+                ),
+                MatOI.LPForm{Float64, typeof(A), typeof(c)}(
+                    sense, c, A, b, b, v_lb, v_ub
+                ),
+                MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}(
+                    sense, c, A, b, [MatOI.EQUAL_TO, MatOI.EQUAL_TO], v_lb, v_ub
+                )
             ]
-                test_expected(MatOI.change_form(F, lp))
+                test_expected(lp)
+                @testset "to $F" for F in [
+                    #MatOI.LPStandardForm{Float64, typeof(A)}, # FIXME doesn't work as the form gets bloated in the conversion
+                    MatOI.LPForm{Float64, typeof(A), typeof(c)},
+                    MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
+                ]
+                    test_expected(MatOI.change_form(F, lp))
+                end
             end
         end
-    end
-    @testset "Geometric form LP" begin
-        s = """
-        variables: x1, x2
-        c1:  x1 + 3x2 <= 7.0
-        c2: 2x1 + 4x2 <= 8.0
-        maxobjective: 5x1 + 6x2
-        """
-        expected = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(expected, s)
+        @testset "Geometric form LP" begin
+            s = """
+            variables: x1, x2
+            c1:  x1 + 3x2 <= 7.0
+            c2: 2x1 + 4x2 <= 8.0
+            maxobjective: 5x1 + 6x2
+            """
+            expected = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(expected, s)
 
-        var_names = ["x1", "x2"]
-        con_names = ["c1", "c2"]
-        model = MOIU.Model{Float64}()
+            var_names = ["x1", "x2"]
+            con_names = ["c1", "c2"]
+            model = MOIU.Model{Float64}()
 
-        sense = MOI.MAX_SENSE
-        v_lb = [-Inf, -Inf]
-        v_ub = [Inf, Inf]
+            sense = MOI.MAX_SENSE
+            v_lb = [-Inf, -Inf]
+            v_ub = [Inf, Inf]
 
-        function test_expected(form)
-            MOI.copy_to(model, form, copy_names = false)
-            MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
-            MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}.(1:2), con_names)
-            MOIU.test_models_equal(model, expected, var_names, con_names)
-        end
+            function test_expected(form)
+                MOI.copy_to(model, form, copy_names = false)
+                MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
+                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}.(1:2), con_names)
+                MOIU.test_models_equal(model, expected, var_names, con_names)
+            end
 
-        @testset "change $(typeof(lp))" for lp in [
-            MatOI.LPGeometricForm{Float64, typeof(A'), typeof(c)}(
-                sense, b, A', c
-            ),
-            MatOI.LPForm{Float64, typeof(A'), typeof(c)}(
-                sense, b, A', [-Inf, -Inf], c, v_lb, v_ub
-            ),
-            MatOI.LPSolverForm{Float64, typeof(A'), typeof(c)}(
-                sense, b, A', c, [MatOI.LESS_THAN, MatOI.LESS_THAN], v_lb, v_ub
-            )
-        ]
-            test_expected(lp)
-            @testset "to $F" for F in [
-                MatOI.LPGeometricForm{Float64, typeof(A), typeof(c)},
-                MatOI.LPForm{Float64, typeof(A), typeof(c)},
-                MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
+            @testset "change $(typeof(lp))" for lp in [
+                MatOI.LPGeometricForm{Float64, typeof(A'), typeof(c)}(
+                    sense, b, A', c
+                ),
+                MatOI.LPForm{Float64, typeof(A'), typeof(c)}(
+                    sense, b, A', [-Inf, -Inf], c, v_lb, v_ub
+                ),
+                MatOI.LPSolverForm{Float64, typeof(A'), typeof(c)}(
+                    sense, b, A', c, [MatOI.LESS_THAN, MatOI.LESS_THAN], v_lb, v_ub
+                )
             ]
-                test_expected(MatOI.change_form(F, lp))
+                test_expected(lp)
+                @testset "to $F" for F in [
+                    MatOI.LPGeometricForm{Float64, typeof(A), typeof(c)},
+                    MatOI.LPForm{Float64, typeof(A), typeof(c)},
+                    MatOI.LPSolverForm{Float64, typeof(A), typeof(c)}
+                ]
+                    test_expected(MatOI.change_form(F, lp))
+                end
             end
         end
     end


### PR DESCRIPTION
See #3: defining a LP problem with `CuArrays` could help integrating `MatOI` inside [Simplex.jl](https://github.com/exanauts/Simplex.jl)