### PR TITLE
Remove get_conic_form and add sparse conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,7 @@ MathOptInterface = "0.9"
 julia = "1"
 
 [extras]
-COSMO = "1e616198-aa4e-51ec-90a2-23f7fbd31d8d"
-ProxSDP = "65e78d25-6039-50a4-9445-38022e3d2eb3"
-SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SCS", "ProxSDP", "COSMO"]
+test = ["Test"]

--- a/src/sparse_matrix.jl
+++ b/src/sparse_matrix.jl
@@ -42,3 +42,20 @@ end
 function load_terms(A::SparseMatrixCSRtoCSC, indexmap, func, offset)
     _load_terms(A.colptr, A.rowval, A.nzval, indexmap, func.terms, offset)
 end
+
+"""
+    Base.convert(::Type{SparseMatrixCSC{Tv, Ti}}, A::SparseMatrixCSRtoCSC{Tv, Ti}) where {Tv, Ti}
+
+Converts `A` to a `SparseMatrixCSC`. Note that the field `A.nzval` is **not
+copied** so if `A` is modified after the call of this function, it can still
+affect the value returned.
+"""
+function Base.convert(::Type{SparseMatrixCSC{Tv, Ti}}, A::SparseMatrixCSRtoCSC{Tv, Ti}) where {Tv, Ti}
+    return SparseMatrixCSC{Tv, Ti}(
+        A.m,
+        A.n,
+        A.colptr .+ one(Ti),
+        A.rowval .+ one(Ti),
+        A.nzval
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,4 @@
 using SparseArrays, Test
-using SCS
-using ProxSDP
-using COSMO
 
 import MatrixOptInterface
 


### PR DESCRIPTION
Should allow to get rid of https://github.com/jump-dev/DiffOpt.jl/blob/1f05b57910642a858f2edfed32c0d26cacc3d80a/src/utils.jl#L153-L164