### PR TITLE
Add support for one-indexing

### DIFF
--- a/src/sparse_matrix.jl
+++ b/src/sparse_matrix.jl
@@ -1,11 +1,24 @@
-mutable struct SparseMatrixCSRtoCSC{Tv,Ti<:Integer}
+abstract type AbstractIndexing end
+struct ZeroBasedIndexing <: AbstractIndexing end
+struct OneBasedIndexing <: AbstractIndexing end
+
+first_index(::ZeroBasedIndexing) = 0
+first_index(::OneBasedIndexing) = 1
+shift(x, ::ZeroBasedIndexing, ::ZeroBasedIndexing) = x
+shift(x::Integer, ::ZeroBasedIndexing, ::OneBasedIndexing) = x + 1
+shift(x::Array{<:Integer}, ::ZeroBasedIndexing, ::OneBasedIndexing) = x .+ 1
+shift(x::Integer, ::OneBasedIndexing, ::ZeroBasedIndexing) = x - 1
+shift(x, ::OneBasedIndexing, ::OneBasedIndexing) = x
+
+mutable struct SparseMatrixCSRtoCSC{Tv,Ti<:Integer,I<:AbstractIndexing}
+    indexing::I
     m::Int # Number of rows
     n::Int # Number of columns
     colptr::Vector{Ti}
     rowval::Vector{Ti}
     nzval::Vector{Tv}
-    function SparseMatrixCSRtoCSC{Tv, Ti}(n) where {Tv, Ti<:Integer}
-        A = new()
+    function SparseMatrixCSRtoCSC{Tv, Ti, I}(n) where {Tv, Ti<:Integer, I}
+        A = new{Tv, Ti, I}()
         A.n = n
         A.colptr = zeros(Ti, n + 1)
         return A
@@ -20,9 +33,9 @@ function allocate_nonzeros(A::SparseMatrixCSRtoCSC{Tv, Ti}) where {Tv, Ti}
 end
 function final_touch(A::SparseMatrixCSRtoCSC)
     for i in length(A.colptr):-1:2
-        A.colptr[i] = A.colptr[i - 1]
+        A.colptr[i] = shift(A.colptr[i - 1], ZeroBasedIndexing(), A.indexing)
     end
-    A.colptr[1] = 0
+    A.colptr[1] = first_index(A.indexing)
 end
 function _allocate_terms(colptr, indexmap, terms)
     for term in terms
@@ -35,27 +48,28 @@ end
 function _load_terms(colptr, rowval, nzval, indexmap, terms, offset)
     for term in terms
         ptr = colptr[indexmap[term.scalar_term.variable_index].value] += 1
-        rowval[ptr] = offset + term.output_index - 1
+        rowval[ptr] = offset + term.output_index
         nzval[ptr] = -term.scalar_term.coefficient
     end
 end
 function load_terms(A::SparseMatrixCSRtoCSC, indexmap, func, offset)
-    _load_terms(A.colptr, A.rowval, A.nzval, indexmap, func.terms, offset)
+    _load_terms(A.colptr, A.rowval, A.nzval, indexmap, func.terms, shift(offset, OneBasedIndexing(), A.indexing))
 end
 
 """
-    Base.convert(::Type{SparseMatrixCSC{Tv, Ti}}, A::SparseMatrixCSRtoCSC{Tv, Ti}) where {Tv, Ti}
+    Base.convert(::Type{SparseMatrixCSC{Tv, Ti}}, A::SparseMatrixCSRtoCSC{Tv, Ti, I}) where {Tv, Ti, I}
 
 Converts `A` to a `SparseMatrixCSC`. Note that the field `A.nzval` is **not
 copied** so if `A` is modified after the call of this function, it can still
-affect the value returned.
+affect the value returned. Moreover, if `I` is `OneBasedIndexing`, `colptr`
+and `rowval` are not copied either, i.e., the conversion is allocation-free.
 """
 function Base.convert(::Type{SparseMatrixCSC{Tv, Ti}}, A::SparseMatrixCSRtoCSC{Tv, Ti}) where {Tv, Ti}
     return SparseMatrixCSC{Tv, Ti}(
         A.m,
         A.n,
-        A.colptr .+ one(Ti),
-        A.rowval .+ one(Ti),
-        A.nzval
+        shift(A.colptr, A.indexing, OneBasedIndexing()),
+        shift(A.rowval, A.indexing, OneBasedIndexing()),
+        A.nzval,
     )
 end


### PR DESCRIPTION
Copying `rowval` can be costly so it's better to create is with the right indexing immediately.
With this PR, different indexing are allowed so that for instance SCS can use zero-based indexing as this is what is needed by the solver and DiffOpt can use one-based indexing as it allows it to to an allocation-free conversion to `SparseMatrixCSC`.