### PR TITLE
Add support to MOI 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-MathOptInterface = "0.9"
+MathOptInterface = "0.10"
 julia = "1"
 
 [extras]

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -94,7 +94,7 @@ end
 function MOI.set(model::GeometricConicForm, ::MOI.ObjectiveSense, sense::MOI.OptimizationSense)
     model.sense = sense
 end
-variable_index_value(t::MOI.ScalarAffineTerm) = t.variable_index.value
+variable_index_value(t::MOI.ScalarAffineTerm) = t.variable.value
 variable_index_value(t::MOI.VectorAffineTerm) = variable_index_value(t.scalar_term)
 function MOI.set(model::GeometricConicForm{T}, ::MOI.ObjectiveFunction,
                  f::MOI.ScalarAffineFunction{T}) where {T}
@@ -141,14 +141,14 @@ function _load_constraints(model::GeometricConicForm, src, indexmap, cone_offset
     end
 end
 
-function MOI.copy_to(dest::GeometricConicForm{T}, src::MOI.ModelLike; copy_names::Bool=true) where T
+function MOI.copy_to(dest::GeometricConicForm{T}, src::MOI.ModelLike) where T
     MOI.empty!(dest)
 
     vis_src = MOI.get(src, MOI.ListOfVariableIndices())
     idxmap = MOIU.IndexMap()
 
     has_constraints = BitSet()
-    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
         i = get(dest.cone_types_dict, S, nothing)
         if i === nothing || F != MOI.VectorAffineFunction{T}
             throw(MOI.UnsupportedConstraint{F, S}())
@@ -167,10 +167,10 @@ function MOI.copy_to(dest::GeometricConicForm{T}, src::MOI.ModelLike; copy_names
     _load_variables(dest, length(vis_src))
 
     # Set variable attributes
-    MOIU.pass_attributes(dest, src, copy_names, idxmap, vis_src)
+    MOIU.pass_attributes(dest, src, idxmap, vis_src)
 
     # Set model attributes
-    MOIU.pass_attributes(dest, src, copy_names, idxmap)
+    MOIU.pass_attributes(dest, src, idxmap)
 
     # Load constraints
     offset = 0

--- a/src/sparse_matrix.jl
+++ b/src/sparse_matrix.jl
@@ -39,7 +39,7 @@ function final_touch(A::SparseMatrixCSRtoCSC)
 end
 function _allocate_terms(colptr, indexmap, terms)
     for term in terms
-        colptr[indexmap[term.scalar_term.variable_index].value + 1] += 1
+        colptr[indexmap[term.scalar_term.variable].value + 1] += 1
     end
 end
 function allocate_terms(A::SparseMatrixCSRtoCSC, indexmap, func)
@@ -47,7 +47,7 @@ function allocate_terms(A::SparseMatrixCSRtoCSC, indexmap, func)
 end
 function _load_terms(colptr, rowval, nzval, indexmap, terms, offset)
     for term in terms
-        ptr = colptr[indexmap[term.scalar_term.variable_index].value] += 1
+        ptr = colptr[indexmap[term.scalar_term.variable].value] += 1
         rowval[ptr] = offset + term.output_index
         nzval[ptr] = -term.scalar_term.coefficient
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,11 +47,9 @@ const dense_A = [1.0 2.0
 
             function test_expected(form)
                 MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form)
-                # TODO: `ConstraintName`s are not supported for `VariableIndex` constraints.
-                # MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
-                # MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
-                # MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
-                # MOIT.util_test_models_equal(model, expected, var_names, [con_names; vcon_names])
+                MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
+                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
+                MOIT.util_test_models_equal(model, expected, var_names, con_names)
             end
 
             @testset "change $(typeof(lp))" for lp in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ const MatOI = MatrixOptInterface
 const MOI = MatOI.MOI
 const MOIU = MatOI.MOIU
 const MOIB = MOI.Bridges
+const MOIT = MOI.Test
 
 
 const ATOL = 1e-4
@@ -45,11 +46,12 @@ const dense_A = [1.0 2.0
             v_ub = [Inf, Inf]
 
             function test_expected(form)
-                MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form, copy_names = false)
-                MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
-                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
-                MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
-                MOIU.test_models_equal(model, expected, var_names, [con_names; vcon_names])
+                MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form)
+                # TODO: `ConstraintName`s are not supported for `VariableIndex` constraints.
+                # MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
+                # MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
+                # MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
+                # MOIT.util_test_models_equal(model, expected, var_names, [con_names; vcon_names])
             end
 
             @testset "change $(typeof(lp))" for lp in [
@@ -92,10 +94,10 @@ const dense_A = [1.0 2.0
             v_ub = [Inf, Inf]
 
             function test_expected(form)
-                MOI.copy_to(model, form, copy_names = false)
+                MOI.copy_to(model, form)
                 MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
                 MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}.(1:2), con_names)
-                MOIU.test_models_equal(model, expected, var_names, con_names)
+                MOIT.util_test_models_equal(model, expected, var_names, con_names)
             end
 
             @testset "change $(typeof(lp))" for lp in [


### PR DESCRIPTION
All tests are passing, except [this one](https://github.com/frapac/MatrixOptInterface.jl/blob/fp/moi_0.10/test/runtests.jl#L51-L54):
```julia
MOI.copy_to(MOI.Bridges.Constraint.Scalarize{Float64}(model), form)
MOI.set(model, MOI.VariableName(), MOI.VariableIndex.(1:2), var_names)
MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}.(1:2), con_names)
MOI.set(model, MOI.ConstraintName(), MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}.(1:2), vcon_names)
MOIT.util_test_models_equal(model, expected, var_names, [con_names; vcon_names])
```

The problem is that `VariableIndex` does not support `ConstraintName` (whereas previously, `SingleVariable` does). Not sure what exactly to do about that.